### PR TITLE
Refactor code to ease maintenance

### DIFF
--- a/autoload/erlang_compiler.vim
+++ b/autoload/erlang_compiler.vim
@@ -1,0 +1,107 @@
+" vim-erlang-compiler file
+" Language:     Erlang
+" Author:       Pawel 'kTT' Salata <rockplayer.pl@gmail.com>
+" Contributors: Ricardo Catalinas Jiménez <jimenezrick@gmail.com>
+"               James Fish <james@fishcakez.com>
+" License:      Vim license
+" Version:      2014/02/04
+
+if exists('g:autoloaded_erlang_compiler')
+    finish
+endif
+
+let g:autoloaded_erlang_compiler = 1
+
+sign define ErlangError   text=>> texthl=Error
+sign define ErlangWarning text=>> texthl=Todo
+
+function erlang_compiler#EnableShowErrors()
+    augroup erlang_compiler
+        autocmd!
+        autocmd BufWritePost *.erl call erlang_compiler#Run()
+        autocmd CursorHold,CursorMoved *.erl,*.hrl call erlang_compiler#ShowErrorMsg()
+    augroup END
+endfunction
+
+function erlang_compiler#DisableShowErrors()
+    sign unplace *
+    augroup erlang_compiler
+        autocmd!
+    augroup END
+endfunction
+
+function erlang_compiler#ShowErrorMsg()
+    let buffer = bufnr("%")
+    let pos = getpos(".")
+    if exists("g:erlang_error_list") && has_key(g:erlang_error_list, buffer)
+                \ && has_key(g:erlang_error_list[buffer], pos[1])
+        let item = get(get(g:erlang_error_list, buffer), pos[1])
+        echo item.text
+        let b:is_showing_msg = 1
+    else
+        if exists("b:is_showing_msg") && b:is_showing_msg
+            echo
+            let b:is_showing_msg = 0
+        endif
+    endif
+endf
+
+function erlang_compiler#ClearErrors()
+    sign unplace *
+    let g:erlang_error_list   = {}
+    let g:erlang_next_sign_id = 1
+    if exists("b:is_showing_msg") && b:is_showing_msg
+        echo
+    end
+    let b:is_showing_msg = 0
+endfunction
+
+function erlang_compiler#Run()
+    let info = erlang_compiler#GetLocalInfo()
+    try
+        compiler erlang
+        setlocal shellpipe=>
+        silent make!
+        call erlang_compiler#ShowErrors()
+    finally
+        call erlang_compiler#SetLocalInfo(info)
+    endtry
+endfunction
+
+
+function erlang_compiler#ShowErrors()
+    call erlang_compiler#ClearErrors()
+    for error in getqflist()
+        " QF locations in an unnamed file (i.e. generic warnings) get bufnr=0: Ignore these.
+        " NB: getqflist can give us a previously not-loaded buffer nr
+        " which may not even appear in :bufs/:ls but is available and all
+        " marks are pre-loaded if you navigate to it from the qflist
+        if error.bufnr == 0
+            continue
+        endif
+        let item          = {}
+        let item["bufnr"] = error.bufnr
+        let item["lnum"]  = error.lnum
+        let item["text"]  = error.text
+        if !has_key(g:erlang_error_list, error.bufnr)
+            let g:erlang_error_list[error.bufnr] = {}
+        endif
+        let g:erlang_error_list[error.bufnr][error.lnum] = item
+        let type = error.type == "W" ? "ErlangWarning" : "ErlangError"
+        execute "sign place" g:erlang_next_sign_id "line=" . item.lnum "name=" . type "buffer=" . item.bufnr
+        let g:erlang_next_sign_id += 1
+    endfor
+endfunction
+
+function erlang_compiler#GetLocalInfo()
+    return [get(b:, 'current_compiler', ''), &l:makeprg, &l:efm, &l:shellpipe]
+endfunction
+
+function erlang_compiler#SetLocalInfo(info)
+    let [name, &l:makeprg, &l:efm, &l:shellpipe] = a:info
+    if empty(name)
+        unlet! b:current_compiler
+    else
+        let b:current_compiler = name
+    endif
+endfunction

--- a/compiler/erlang.vim
+++ b/compiler/erlang.vim
@@ -1,116 +1,34 @@
-" Vim compiler file
+" vim-erlang-compiler file
 " Language:     Erlang
 " Author:       Pawel 'kTT' Salata <rockplayer.pl@gmail.com>
 " Contributors: Ricardo Catalinas Jiménez <jimenezrick@gmail.com>
+"               James Fish <james@fishcakez.com>
 " License:      Vim license
-" Version:      2012/02/08
+" Version:      2014/02/04
 
 if exists("current_compiler") || v:version < 703
-	finish
+    finish
 else
-	let current_compiler = "erlang"
+    let current_compiler = "erlang"
 endif
 
-let b:error_list     = {}
-let b:is_showing_msg = 0
-let b:next_sign_id   = 1
+let s:cpo_save = &cpo
+set cpo-=C
 
 if exists(":CompilerSet") != 2
-	command -nargs=* CompilerSet setlocal <args>
+    command -nargs=* CompilerSet setlocal <args>
 endif
 
-CompilerSet makeprg=make
+
+if match(getline(1), "#!.*escript") != -1
+    CompilerSet makeprg=escript\ -s\ %
+else
+    let s:erlang_check_file = expand("<sfile>:p:h") . "/erlang_check.erl"
+    execute "CompilerSet makeprg=" . fnameescape(s:erlang_check_file) . "\\ \%"
+    unlet s:erlang_check_file
+endif
+
 CompilerSet errorformat=%f:%l:\ %tarning:\ %m,%f:%l:\ %m
 
-" Only define functions and script scope variables once
-if exists("*s:ShowErrors")
-	finish
-endif
-
-if !exists("g:erlang_show_errors")
-	let g:erlang_show_errors = 1
-endif
-
-let s:erlang_check_file = expand("<sfile>:p:h") . "/erlang_check.erl"
-let s:autocmds_defined  = 0
-
-sign define ErlangError   text=>> texthl=Error
-sign define ErlangWarning text=>> texthl=Todo
-
-command ErlangDisableShowErrors silent call s:DisableShowErrors()
-command ErlangEnableShowErrors  silent call s:EnableShowErrors()
-
-function s:ShowErrors()
-	setlocal shellpipe=>
-	if match(getline(1), "#!.*escript") != -1
-		setlocal makeprg=escript\ -s\ %
-	else
-		execute "setlocal makeprg=" . s:erlang_check_file . "\\ \%"
-	endif
-	silent make!
-	call s:ClearErrors()
-	for error in getqflist()
-		" QF locations in an unnamed file (i.e. generic warnings) get bufnr=0: Ignore these.
-		" NB: getqflist can give us a previously not-loaded buffer nr
-		" which may not even appear in :bufs/:ls but is available and all
-		" marks are pre-loaded if you navigate to it from the qflist
-		if error.bufnr == 0
-			continue
-		endif
-		let item          = {}
-		let item["bufnr"] = error.bufnr
-		let item["lnum"]  = error.lnum
-		let item["text"]  = error.text
-		let b:error_list[error.lnum] = item
-		let type = error.type == "W" ? "ErlangWarning" : "ErlangError"
-		execute "sign place" b:next_sign_id "line=" . item.lnum "name=" . type "buffer=" . item.bufnr
-		let b:next_sign_id += 1
-	endfor
-	setlocal shellpipe&
-	setlocal makeprg=make
-endfunction
-
-function s:ShowErrorMsg()
-	let pos = getpos(".")
-	if has_key(b:error_list, pos[1])
-		let item = get(b:error_list, pos[1])
-		echo item.text
-		let b:is_showing_msg = 1
-	else
-		if b:is_showing_msg
-			echo
-			let b:is_showing_msg = 0
-		endif
-	endif
-endf
-
-function s:ClearErrors()
-	sign unplace *
-	let b:error_list   = {}
-	let b:next_sign_id = 1
-	if b:is_showing_msg
-		echo
-		let b:is_showing_msg = 0
-	endif
-endfunction
-
-function s:EnableShowErrors()
-	if !s:autocmds_defined
-		autocmd BufWritePost *.erl call s:ShowErrors()
-		autocmd CursorHold   *.erl call s:ShowErrorMsg()
-		autocmd CursorMoved  *.erl call s:ShowErrorMsg()
-		let s:autocmds_defined = 1
-	endif
-endfunction
-
-function s:DisableShowErrors()
-	sign unplace *
-	autocmd! BufWritePost *.erl
-	autocmd! CursorHold   *.erl
-	autocmd! CursorMoved  *.erl
-	let s:autocmds_defined = 0
-endfunction
-
-if g:erlang_show_errors
-	call s:EnableShowErrors()
-endif
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/plugin/erlang_compiler.vim
+++ b/plugin/erlang_compiler.vim
@@ -1,0 +1,20 @@
+" vim-erlang-compiler file
+" Language:     Erlang
+" Author:       Pawel 'kTT' Salata <rockplayer.pl@gmail.com>
+" Contributors: Ricardo Catalinas Jiménez <jimenezrick@gmail.com>
+"               James Fish <james@fishcakez.com>
+" License:      Vim license
+" Version:      2014/02/04
+
+if exists('g:loaded_erlang_compiler')
+    finish
+endif
+
+let g:loaded_erlang_compiler = 1
+
+if !exists("g:erlang_show_errors") || g:erlang_show_errors
+    call erlang_compiler#EnableShowErrors()
+endif
+
+command ErlangDisableShowErrors silent call erlang_compiler#DisableShowErrors()
+command ErlangEnableShowErrors  silent call erlang_compiler#EnableShowErrors()


### PR DESCRIPTION
The following bugs were fixed during refactoring:
- Compiler can be used standalone without side effects
- The local compiler/shellpipe is not changed after writing a file
- Error text will now be echoed in .hrl files
- Error text will only be echoed for the last check
