### PR TITLE
Only 'sign place' when lnum > 0

### DIFF
--- a/autoload/erlang_compiler/errors.vim
+++ b/autoload/erlang_compiler/errors.vim
@@ -107,7 +107,9 @@ endfunction
 
 function erlang_compiler#errors#AddSign(error_id, error)
     let type = a:error.type == "W" ? "ErlangWarning" : "ErlangError"
-    execute "sign place" a:error_id "line=" . a:error.lnum "name=" . type "buffer=" . a:error.bufnr
+    if lnum > 0
+        execute "sign place" a:error_id "line=" . a:error.lnum "name=" . type "buffer=" . a:error.bufnr
+    endif
 endfunction
 
 function erlang_compiler#errors#DelSign(error_id)


### PR DESCRIPTION
`erlc` produces errors with line nr 0, e.g. when you try to compile with `lager_transform` but `lager` is not yet compiled. If it does, you get this error:

```
Error detected while processing function erlang_compiler#AutoRun..erlang_compiler#errors#SetList..erlang_compiler#errors#AddError..erlang_compiler#errors#AddSign:
line    2:
E885: Not possible to change sign ErlangError
```
