### PR TITLE
Add support for non-rebar buildsystems

### DIFF
--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -235,7 +235,15 @@ read_file_type(Fd) ->
 check_module(File) ->
     Dir = filename:dirname(File),
     AbsFile = filename:absname(File),
-    AbsDir = filename:absname(Dir),
+    Path = filename:absname(Dir),
+    ProjectRoot = case find_app_root(Path) of
+                      no_root ->
+                          log("Could not find project root.~n"),
+                          Path;
+                      Root ->
+                          log("Found project root: ~p~n", [Root]),
+                          Root
+                  end,
 
     Defs = [warn_export_all,
             warn_export_vars,
@@ -245,26 +253,23 @@ check_module(File) ->
             report,
             % By adding debug_info, we ensure that the output of xref:m will
             % contain the caller MFAs too.
-            debug_info,
-            {i, AbsDir ++ "/include"},
-            {i, AbsDir ++ "/../include"},
-            {i, AbsDir ++ "/../../include"},
-            {i, AbsDir ++ "/../../../include"}],
+            debug_info],
 
-    case process_rebar_configs(AbsDir) of
-        {ok, RebarOpts} ->
-            code:add_patha(absname(AbsDir, "ebin")),
-            {CompileOpts0, OutDir} =
-                case get(outdir) of
-                    undefined ->
-                        % strong_validation = we only want validation, don't
-                        % generate beam file
-                        {[strong_validation], undefined};
-                    OutDir0 ->
-                        AbsOutDir = filename:join(AbsDir, OutDir0),
-                        {[{outdir, AbsOutDir}], AbsOutDir}
-                end,
-            CompileOpts = CompileOpts0 ++ Defs ++ RebarOpts,
+    {BuildSystem, Files} = guess_build_system(ProjectRoot),
+    BuildSystemOpts = load_build_files(BuildSystem, ProjectRoot, Files),
+    {ExtOpts, OutDir} = case get(outdir) of
+                            undefined ->
+                                {[strong_validation], undefined};
+                            OutDir0 ->
+                                AbsOutDir = filename:join(ProjectRoot, OutDir0),
+                                {[{outdir, AbsOutDir}], AbsOutDir}
+                        end,
+
+    case BuildSystemOpts of
+        {result, Result} ->
+            log("Result: ~p", [Result]);
+        {opts, Opts} ->
+            CompileOpts = Defs ++ Opts ++ ExtOpts,
             log("Code paths: ~p~n", [code:get_path()]),
             log("Compiling: compile:file(~p,~n    ~p)~n",
                 [AbsFile, CompileOpts]),
@@ -277,6 +282,234 @@ check_module(File) ->
         error ->
             error
     end.
+
+%%------------------------------------------------------------------------------
+%% @doc Traverse the director structure upwards until is_app_root matches.
+%% @end
+%%------------------------------------------------------------------------------
+-spec find_app_root(string()) -> Root :: string() | 'no_root'.
+find_app_root("/") ->
+    case is_app_root("/") of
+        true -> "/";
+        false -> no_root
+    end;
+find_app_root(Path) ->
+    case is_app_root(Path) of
+        true -> Path;
+        false -> find_app_root(filename:dirname(Path))
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Check directory if it is the root of an OTP application.
+%% @end
+%%------------------------------------------------------------------------------
+-spec is_app_root(string()) -> true | false.
+is_app_root(Path) ->
+    filelib:wildcard("ebin/*.app", Path) /= [] orelse
+    filelib:wildcard("src/*.app.src", Path) /= [].
+
+%%------------------------------------------------------------------------------
+%% @doc Check for some known files and try to guess what build system is being
+%% used.
+%% @end
+%%------------------------------------------------------------------------------
+-spec guess_build_system(string()) -> {atom(), string()}.
+guess_build_system(Path) ->
+    % The order is important, at least Makefile needs to come last since a lot
+    % of projects include a Makefile along any other build system.
+    BuildSystems = [
+                    {rebar, [
+                             "rebar.config",
+                             "rebar.config.script"
+                            ]
+                    },
+                    {makefile, [
+                            "Makefile"
+                           ]
+                    }
+                   ],
+    guess_build_system(Path, BuildSystems).
+
+guess_build_system(_Path, []) ->
+    log("Unknown build system"),
+    {unknown_build_system, []};
+guess_build_system(Path, [{BuildSystem, Files}|Rest]) ->
+    log("Try build system: ~p~n", [BuildSystem]),
+    case find_files(Path, Files) of
+        [] -> guess_build_system(Path, Rest);
+        FoundFiles when is_list(FoundFiles) -> {BuildSystem, FoundFiles}
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Recursively search upward through the path tree and returns the absolute
+%% path to all files matching the given filenames.
+%% @end
+%%------------------------------------------------------------------------------
+-spec find_files(string(), [string()]) -> [string()].
+find_files("/", Files) ->
+    find_file("/", Files);
+find_files(Path, Files) ->
+    %find_files(Path, Files, Files).
+    ParentPath = filename:dirname(Path),
+    find_file(Path, Files) ++
+    find_files(ParentPath, Files).
+
+%%------------------------------------------------------------------------------
+%% @doc Find the first file matching one of the filenames in the given path.
+%% @end
+%%------------------------------------------------------------------------------
+-spec find_file(string(), [string()]) -> [string()].
+find_file(_Path, []) ->
+    [];
+find_file(Path, [File|Rest]) ->
+    AbsFile = absname(Path, File),
+    case filelib:is_regular(AbsFile) of
+        true ->
+            log("Found build file: [~p] ~p~n", [Path, AbsFile]),
+            % Return file and continue searching in parent directory.
+            [AbsFile];
+        false ->
+            find_file(Path, Rest)
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Load the settings from a given set of build system files.
+%% @end
+%%------------------------------------------------------------------------------
+-spec load_build_files(atom(), string(), [string()]) ->
+    {opts, [{atom(), term()}]} |
+    {result, term()} |
+    error.
+load_build_files(rebar, _Path, ConfigFiles) ->
+    load_rebar_files(ConfigFiles, no_config);
+load_build_files(makefile, _Path, ConfigFiles) ->
+    load_makefiles(ConfigFiles);
+load_build_files(unknown_build_system, Path, _) ->
+    {opts, [
+            {i, absname(Path, "include")},
+            {i, absname(Path, "../include")},
+            {i, Path}
+           ]}.
+
+%%------------------------------------------------------------------------------
+%% @doc Load the content of each rebar file.
+%% Note worthy: The config returned by this function only represent the first
+%% rebar file (the one closest to the file to compile). The subsequent rebar
+%% files will be processed for code path only.
+%% @end
+%%------------------------------------------------------------------------------
+-spec load_rebar_files([string()], no_config | [term()]) ->
+    {ok, [{atom(), term()}]} | error.
+load_rebar_files([], no_config) ->
+    error;
+load_rebar_files([], Config) ->
+    {opts, Config};
+load_rebar_files([ConfigFile|Rest], Config) ->
+    ConfigPath = filename:dirname(ConfigFile),
+    ConfigResult = case filename:extension(ConfigFile) of
+                       ".script" -> file:script(ConfigFile);
+                       ".config" -> file:consult(ConfigFile)
+                   end,
+    case ConfigResult of
+        {ok, ConfigTerms} ->
+            log("rebar.config read: ~s~n", [ConfigFile]),
+            NewConfig = process_rebar_config(ConfigPath, ConfigTerms, Config),
+            case load_rebar_files(Rest, NewConfig) of
+                {opts, SubConfig} -> {opts, SubConfig};
+                error -> {ok, NewConfig}
+            end;
+        {error, Reason} ->
+            log_error("rebar.config consult failed:~n"),
+            file_error(ConfigFile, Reason),
+            error
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Apply a rebar.config file.
+%%
+%% This function adds the directories in the rebar.config file to the code path
+%% and returns and compilation options to be used when compiling the file.
+%% @end
+%%------------------------------------------------------------------------------
+-spec process_rebar_config(string(), [{atom(), term()}], [] | no_config) ->
+    [{atom(), term()}].
+process_rebar_config(Path, Terms, Config) ->
+
+    % App layout:
+    %
+    % * rebar.config
+    % * src/
+    % * ebin/ => ebin -> code_path
+    % * include/ => ".." -> include. This is needed because files in src may
+    %                use `-include_lib("appname/include/f.hrl")`
+
+    % Project layout:
+    %
+    % * rebar.config
+    % * src/
+    % * $(deps_dir)/
+    %   * $(app_name)/
+    %     * ebin/ => deps -> code_path
+    % * apps/
+    %   * $(sub_dir)/
+    %     * ebin/ => sub_dirs -> code_path
+    %     * include/ => apps -> include
+
+    DepsDir = proplists:get_value(deps_dir, Terms, "deps"),
+    LibDirs = proplists:get_value(lib_dirs, Terms, []),
+    SubDirs = proplists:get_value(sub_dirs, Terms, []),
+    ErlOpts = proplists:get_value(erl_opts, Terms, []),
+
+    % ebin -> code_path (when the rebar.config file is in the app directory
+    code:add_pathsa([absname(Path, "ebin")]),
+
+    % deps -> code_path
+    code:add_pathsa(filelib:wildcard(absname(Path, DepsDir) ++ "/*/ebin")),
+    
+    % libs -> code_path
+    code:add_pathsa(filelib:wildcard(absname(Path, LibDirs) ++ "/*/ebin")),
+
+    % sub_dirs -> code_path
+    [ code:add_pathsa(filelib:wildcard(absname(Path, SubDir) ++ "/ebin"))
+      || SubDir <- SubDirs ],
+
+    case Config of
+        no_config ->
+            Includes =
+            [ {i, absname(Path, Dir)}
+              || Dir <- ["apps", "include"] ] ++
+            [ {i, absname(Path, filename:append(SubDir, "include"))}
+              || SubDir <- SubDirs ],
+
+            Opts = ErlOpts ++ Includes,
+            % If "warnings_as_errors" is left in, rebar sometimes prints the
+            % following line:
+            %
+            %     compile: warnings being treated as errors
+            %
+            % The problem is that Vim interprets this as a line about an actual
+            % warning about a file called "compile", so it will jump to the
+            % "compile" file.
+            %
+            % And anyway, it is fine to show warnings as warnings as not errors:
+            % the developer know whether their project handles warnings as
+            % errors and interpret them accordingly.
+            proplists:delete(warnings_as_errors, Opts);
+        _ ->
+            Config
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Set code paths and options for a simple Makefile
+%% @end
+%%------------------------------------------------------------------------------
+-spec load_makefiles([string()]) -> {ok, [{atom(), term()}]} | error.
+load_makefiles([Makefile|_Rest]) ->
+    Path = filename:dirname(Makefile),
+    code:add_pathsa([absname(Path, "ebin")]),
+    code:add_pathsa(filelib:wildcard(absname(Path, "deps") ++ "/*/ebin")),
+    {opts, [{i, absname(Path, "include")},
+            {i, absname(Path, "deps")}]}.
 
 %%------------------------------------------------------------------------------
 %% @doc Perform tasks after successful compilation (xref, etc.)
@@ -481,134 +714,6 @@ file_error(File, Reason) ->
     Reason2 = file:format_error(Reason),
     io:format(user, "~s: ~s~n", [File, Reason2]),
     error.
-
-%%------------------------------------------------------------------------------
-%% @doc Find, read and apply the rebar config files appropriate for the given
-%% path.
-%%
-%% This function traverses the directory tree upward until it finds
-%% the root directory. It finds all rebar.config files along the way and applies
-%% all of them (e.g. the dependency directory in all of them is added to the
-%% code path). It returns the options in the first rebar.config file (e.g. the
-%% one that is the closest to the file to be compiled).
-%% @end
-%%------------------------------------------------------------------------------
--spec process_rebar_configs(AbsDir :: string()) ->
-          {ok, Options :: [term()]} | error.
-process_rebar_configs(AbsDir) ->
-    case process_rebar_configs(AbsDir, no_config_yet) of
-        error ->
-            error;
-        Options ->
-            {ok, Options}
-    end.
-
-process_rebar_configs(AbsDir, Options0) ->
-    ConfigFileName = filename:join(AbsDir, "rebar.config"),
-
-    Options =
-        case filelib:is_file(ConfigFileName) of
-            true ->
-                case file:consult(ConfigFileName) of
-                    {ok, ConfigTerms} ->
-                        log("rebar.config read: ~s~n", [ConfigFileName]),
-                        OptionsHere = process_rebar_config(AbsDir, ConfigTerms),
-                        case Options0 of
-                            no_config_yet ->
-                                OptionsHere;
-                            _ ->
-                                Options0
-                        end;
-                    {error, Reason} ->
-                        log_error("rebar.config consult unsuccessful:~n"),
-                        file_error(ConfigFileName, Reason),
-                        error
-                end;
-            false ->
-                Options0
-        end,
-
-    case {Options, AbsDir} of
-        {error, _} ->
-            error;
-        {no_config_yet, "/"} ->
-            [];
-        {_, "/"} ->
-            Options;
-        {_, _} ->
-            process_rebar_configs(filename:dirname(AbsDir), Options)
-    end.
-
-%%------------------------------------------------------------------------------
-%% @doc Apply a rebar.config file.
-%%
-%% This function adds the directories in the rebar.config file to the code path
-%% and returns and compilation options to be used when compiling the file.
-%% @end
-%%------------------------------------------------------------------------------
--spec process_rebar_config(Dir :: string(), ConfigTerms :: [term()]) ->
-          [Option :: term()].
-process_rebar_config(Dir, Terms) ->
-
-    % App layout:
-    %
-    % * rebar.config
-    % * src/
-    % * ebin/ => ebin -> code_path
-    % * include/ => ".." -> include. This is needed because files in src may
-    %                use `-include_lib("appname/include/f.hrl")`
-
-    % Project layout:
-    %
-    % * rebar.config
-    % * src/
-    % * $(deps_dir)/
-    %   * $(app_name)/
-    %     * ebin/ => deps -> code_path
-    % * apps/
-    %   * $(sub_dir)/
-    %     * ebin/ => sub_dirs -> code_path
-    %     * include/ => apps -> include
-
-    Includes =
-
-        % ".." -> include
-        [{i, absname(Dir, "..")},
-
-        % "apps" -> include
-         {i, absname(Dir, "apps")}] ++
-
-        % lib_dirs -> include
-        [ {i, absname(Dir, LibDir)} ||
-          LibDir <- proplists:get_value(lib_dirs, Terms, [])],
-
-
-    % ebin -> code_path (when the rebar.config file is in the app directory)
-    code:add_pathsa([absname(Dir, "ebin")]),
-
-    % deps -> code_path
-    RebarDepsDir = proplists:get_value(deps_dir, Terms, "deps"),
-    code:add_pathsa(filelib:wildcard(absname(Dir, RebarDepsDir) ++ "/*/ebin")),
-
-    % sub_dirs -> code_path
-    [ code:add_pathsa(filelib:wildcard(absname(Dir, SubDir) ++ "/ebin"))
-      || SubDir <- proplists:get_value(sub_dirs, Terms, []) ],
-
-    ErlOpts = proplists:get_value(erl_opts, Terms, []) ++ Includes,
-
-    % If "warnings_as_errors" is left in, rebar sometimes prints the
-    % following line:
-    %
-    %     compile: warnings being treated as errors
-    %
-    % The problem is that Vim interprets this as a line about an actual
-    % warning about a file called "compile", so it will jump to the
-    % "compile" file.
-    %
-    % And anyway, it is fine to show warnings as warnings as not errors:
-    % the developer know whether their project handles warnings as
-    % errors and interpret them accordingly.
-    proplists:delete(warnings_as_errors, ErlOpts).
 
 -spec print_xref_warnings({deprecated, [{mfa(), mfa()}]} |
                           {undefined, [{mfa(), mfa()}]} |

--- a/doc/vim-erlang-compiler.txt
+++ b/doc/vim-erlang-compiler.txt
@@ -156,6 +156,7 @@ Contributors: Ricardo Catalinas Jiménez <jimenezrick@gmail.com>
               Michael Coles <michael.coles@gmail.com>
               James Fish <james@fishcakez.com>
               Csaba Hoch <csaba.hoch@gmail.com>
+              Krister Svanlund <krister.svanlund@gmail.com>
 License:      Vim License (see |license|)
 
 ==============================================================================


### PR DESCRIPTION
The focus on this commit is to remake the check_module call to support for an extensible system to identify the buildsystem used. If rebar is used it should behave kind of like it used to (but less accepting of bullshit application directory structure). The support for other systems currently doesn't extend further than finding Makefiles and then just assuming there is a deps, include and ebin directory.

This also adds support for rebar.config.script.