### PR TITLE
Fix undefined variable error

### DIFF
--- a/compiler/erlang.vim
+++ b/compiler/erlang.vim
@@ -22,6 +22,12 @@ endif
 let g:erlang_compiler_check_script = expand("<sfile>:p:h") . "/erlang_check.erl"
 
 " Find the appropriate make options
+if !exists("g:erlang_make_options")
+    let g:erlang_make_options = ''
+endif
+if !exists("g:erlang_make_options_rules")
+    let g:erlang_make_options_rules = []
+endif
 let s:make_options = g:erlang_make_options
 for s:rule in g:erlang_make_options_rules
     if expand('%:p') =~# get(s:rule, 'path_re', '')


### PR DESCRIPTION
```
Error detected while processing …/vim-erlang-compiler/compiler/erlang.vim:
line   25:
E121: Undefined variable: g:erlang_make_options
E15: Invalid expression: g:erlang_make_options
line   26:
E121: Undefined variable: g:erlang_make_options_rules
E15: Invalid expression: g:erlang_make_options_rules
line   35:
E121: Undefined variable: s:make_options
E116: Invalid arguments for function escape(fnameescape(g:erlang_compiler_check_script) . ' ' .        s:make_options . ' ', ' \') . '%'
E15: Invalid expression: "CompilerSet makeprg=" . escape(fnameescape(g:erlang_compiler_check_script) . ' ' .        s:make_options . ' ', ' \') . '%'
```