### PR TITLE
Smart update quickfix

### DIFF
--- a/autoload/erlang_compiler.vim
+++ b/autoload/erlang_compiler.vim
@@ -54,9 +54,15 @@ function erlang_compiler#AutoRun(buffer)
         compiler erlang
         let &l:makeprg = fnameescape(g:erlang_compiler_check_script) . ' ' .
                        \ erlang_compiler#GetFlymakeOptions() . ' %'
-        setlocal shellpipe=>
-        execute "silent lmake!" shellescape(bufname(a:buffer), 1)
-        call erlang_compiler#errors#SetList(a:buffer, getloclist(0))
+        if !g:erlang_quickfix_support
+            setlocal shellpipe=>
+            execute "silent lmake!" shellescape(bufname(a:buffer), 1)
+            call erlang_compiler#errors#SetList(a:buffer, getloclist(0))
+        else
+            setlocal shellpipe=>
+            execute "silent make!" shellescape(bufname(a:buffer), 1)
+            call erlang_compiler#errors#SetList(a:buffer, getqflist())
+        endif
     finally
         call erlang_compiler#SetLocalInfo(info)
     endtry

--- a/doc/vim-erlang-compiler.txt
+++ b/doc/vim-erlang-compiler.txt
@@ -115,6 +115,10 @@ g:erlang_flymake_options_rules                *g:erlang_flymake_options_rules*
         Similar to |g:erlang_make_options_rules|, but used when performing
         on-the-fly syntax check (a.k.a. flymake). The default value is [].
 
+g:erlang_quickfix_support                          *g:erlang_quickfix_support*
+        Enable |quickfix| support instead of |location-list|.  If `1`,
+        it is enabled, if `0`, it is disabled. The default value is `0`.
+
 COMPILATION OPTIONS                           *vim-erlang-compilation-options*
 
 --outdir DIR

--- a/plugin/erlang_compiler.vim
+++ b/plugin/erlang_compiler.vim
@@ -32,6 +32,10 @@ if !exists("g:erlang_flymake_options_rules")
     let g:erlang_flymake_options_rules = []
 endif
 
+if !exists("g:erlang_quickfix_support")
+    let g:erlang_quickfix_support = 0
+endif
+
 command ErlangDisableShowErrors call erlang_compiler#DisableShowErrors()
 command ErlangEnableShowErrors  call erlang_compiler#EnableShowErrors()
 command ErlangToggleShowErrors  call erlang_compiler#ToggleShowErrors()


### PR DESCRIPTION
Quickfix has been broken since #3 and `:cc`, `:cn` & etc didn't work.