### PR TITLE
Prevent execution before full initialization

### DIFF
--- a/compiler/erlang.vim
+++ b/compiler/erlang.vim
@@ -12,6 +12,10 @@ else
     let current_compiler = "erlang"
 endif
 
+if !exists('g:loaded_erlang_compiler')
+    finish
+endif
+
 let s:cpo_save = &cpo
 set cpo&vim
 


### PR DESCRIPTION
I managed to reproduce issue #14. STR:

1\. Add this plugin using [vim-plug](https://github.com/junegunn/vim-plug): .vimrc and `:PlugInstall`

```
call plug#begin('~/.vim/plugged')
Plug 'vim-erlang/vim-erlang-compiler'
call plug#end()
```

2\. Open vim with erlang file: `vim module.erl`

3\. Getting error:

```
Error detected while processing …/vim-erlang-compiler/compiler/erlang.vim:
line   25:
E121: Undefined variable: g:erlang_make_options
E15: Invalid expression: g:erlang_make_options
line   26:
E121: Undefined variable: g:erlang_make_options_rules
E15: Invalid expression: g:erlang_make_options_rules
line   35:
E121: Undefined variable: s:make_options
E116: Invalid arguments for function escape(fnameescape(g:erlang_compiler_check_script) . ' ' .        s:make_options . ' ', ' \') . '%'
E15: Invalid expression: "CompilerSet makeprg=" . escape(fnameescape(g:erlang_compiler_check_script) . ' ' .        s:make_options . ' ', ' \') . '%'
```

Anyway my previous patch was cruft and I rewrote it. 