### PR TITLE
fix include path, add 'lib' to path

### DIFF
--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -269,8 +269,12 @@ check_module(File) ->
         {result, Result} ->
             log("Result: ~p", [Result]);
         {opts, Opts} ->
-            CompileOpts = Defs ++ Opts ++ ExtOpts ++
-                          [{i, absname(filename:dirname(Path), "include")}],
+            %% for file: .../app/src/xx.erl
+            %% add .../app/src/../include
+            CompileOpts =
+              Defs ++ Opts ++ ExtOpts ++
+              [{i, filename:join([Path, "..", "include"])}
+              ],
             log("Code paths: ~p~n", [code:get_path()]),
             log("Compiling: compile:file(~p,~n    ~p)~n",
                 [AbsFile, CompileOpts]),

--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -647,8 +647,10 @@ load_makefiles([Makefile|_Rest]) ->
     Path = filename:dirname(Makefile),
     code:add_pathsa([absname(Path, "ebin")]),
     code:add_pathsa(filelib:wildcard(absname(Path, "deps") ++ "/*/ebin")),
+    code:add_pathsa(filelib:wildcard(absname(Path, "lib") ++ "/*/ebin")),
     {opts, [{i, absname(Path, "include")},
-            {i, absname(Path, "deps")}]}.
+            {i, absname(Path, "deps")},
+            {i, absname(Path, "lib")}]}.
 
 %%------------------------------------------------------------------------------
 %% @doc Perform tasks after successful compilation (xref, etc.)


### PR DESCRIPTION
A bug fix and an enhancement.

## Fix include path

When the file is opened at `.`, the extra `i` directory will be under `src`
https://github.com/vim-erlang/vim-erlang-compiler/blob/master/compiler/erlang_check.erl#L273

Here is an example from my test output:

```erlang
Erlang/OTP 19 [erts-8.2] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.2  (abort with ^G)
1> File = "a.erl".
"a.erl"
2> Dir = filename:dirname(File).
"."
3> Path = filename:absname(Dir).
"/tmp/app/src/."
4> filename:absname(filename:join(Path, "include")).
"/tmp/app/src/include"
```
the fix is to use `filename:join([Path, "..", "include"])` instead.
in the example, the final dir would be `/tmp/app/src/./../include`

## Add `lib/*/ebin` to code path and `lib` directory for `include_lib`

Makefile umbrella projects usually have libraries in `lib` instead of `deps`
