### PR TITLE
Fix project root for rebar3 projects with apps layout

### DIFF
--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -256,12 +256,13 @@ check_module(File) ->
             debug_info],
 
     {BuildSystem, Files} = guess_build_system(ProjectRoot),
-    BuildSystemOpts = load_build_files(BuildSystem, ProjectRoot, Files),
+    FixedProjectRoot = fix_project_root(BuildSystem, Files, ProjectRoot),
+    BuildSystemOpts = load_build_files(BuildSystem, FixedProjectRoot, Files),
     {ExtOpts, OutDir} = case get(outdir) of
                             undefined ->
                                 {[strong_validation], undefined};
                             OutDir0 ->
-                                AbsOutDir = filename:join(ProjectRoot, OutDir0),
+                                AbsOutDir = filename:join(FixedProjectRoot, OutDir0),
                                 {[{outdir, AbsOutDir}], AbsOutDir}
                         end,
 
@@ -304,6 +305,11 @@ find_app_root(Path) ->
         false -> find_app_root(filename:dirname(Path))
     end.
 
+fix_project_root(rebar3, Files, _) ->
+    [RebarLock] = [F || F <- Files, filename:basename(F) == "rebar.lock"],
+    filename:dirname(RebarLock);
+fix_project_root(_BuildSystem, _Files, ProjectRoot) ->
+    ProjectRoot.
 %%------------------------------------------------------------------------------
 %% @doc Check directory if it is the root of an OTP application.
 %% @end


### PR DESCRIPTION
In projects with apps layout and `rebar.config[.script]` files inside `apps/an_app` the project root was set to `apps/an_app`. Because of that code paths where not loaded correctly and for example
'lager_transform' couldn't be find during compilation.

I run into this issue when we switched from rebar2 to rebar3 in [esl/MongooseIM](https://github.com/esl/MongooseIM)