### PR TITLE
(#25) rebar3: include finds files in <app>/include

### DIFF
--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -274,7 +274,8 @@ check_module(File) ->
             %% add .../app/src/../include
             CompileOpts =
               Defs ++ Opts ++ ExtOpts ++
-              [{i, filename:join([Path, "..", "include"])}
+              [{i, filename:join([Path, "..", "include"])},
+               {i, filename:join([ProjectRoot, "include"])}
               ],
             log("Code paths: ~p~n", [code:get_path()]),
             log("Compiling: compile:file(~p,~n    ~p)~n",


### PR DESCRIPTION
In rebar, we might have the following files:

    app/include/xx.hrl
    app/src/subsir/xx.erl

xx.erl may contain `include("xx.hrl")`. This works in rebar, and now it
also works in vim-erlang-compiler.